### PR TITLE
Fixed incorrect auth parameters pass for API requests for Vkontakte service

### DIFF
--- a/src/Services/Vkontakte.php
+++ b/src/Services/Vkontakte.php
@@ -24,4 +24,14 @@ class Vkontakte extends OAuth2Service
      * @var string
      */
     protected $scopeDelimiter = ',';
+
+    /**
+     * @var null
+     */
+    protected $header = null;
+
+    /**
+     * @var string
+     */
+    protected $queryParam = 'access_token';
 }


### PR DESCRIPTION
As per https://vk.com/dev/api_requests access_token should be passed to all API requests as GET parameter, not as header
