### PR TITLE
Fix for oauth callback required in twitter

### DIFF
--- a/src/OAuth1Service.php
+++ b/src/OAuth1Service.php
@@ -12,6 +12,33 @@ class OAuth1Service extends Service implements OAuth1ServiceInterface
     protected $endpointRequestToken = '';
 
     /**
+     * @var string
+     */
+    protected $oauthCallback = '';
+
+    /**
+     * Set the oauth callback URL to be used in requestToken()
+     *
+     * @param  string  $callback
+     * @return ServiceInterface
+     */
+    public function setOAuthCallback($callback)
+    {
+        $this->oauthCallback = $callback;
+        return $this;
+    }
+
+    /**
+     * Get the oauth callback URL to be used in requestToken()
+     *
+     * @return string
+     */
+    public function getOAuthCallback()
+    {
+        return $this->oauthCallback;
+    }
+
+    /**
      * Request the service a request token.
      *
      * @return array
@@ -26,7 +53,7 @@ class OAuth1Service extends Service implements OAuth1ServiceInterface
         $subscriber = new Oauth1([
             'consumer_key' => $this->credentials['client_id'],
             'consumer_secret' => $this->credentials['client_secret'],
-            'callback' => isset($this->oauth_callback)? $this->oauth_callback: null,
+            'callback' => $this->oauthCallback !== '' ? $this->oauthCallback : null,
         ]);
 
         $this->client->getEmitter()->attach($subscriber);
@@ -65,7 +92,6 @@ class OAuth1Service extends Service implements OAuth1ServiceInterface
             'consumer_key'    => $this->credentials['client_id'],
             'consumer_secret' => $this->credentials['client_secret'],
             'token'           => $oauthToken,
-            'token_secret'    => $this->token['oauth_token_secret'],
         ]);
 
         $body = ['oauth_verifier' => $oauthVerifier];

--- a/src/OAuth1Service.php
+++ b/src/OAuth1Service.php
@@ -26,6 +26,7 @@ class OAuth1Service extends Service implements OAuth1ServiceInterface
         $subscriber = new Oauth1([
             'consumer_key' => $this->credentials['client_id'],
             'consumer_secret' => $this->credentials['client_secret'],
+            'callback' => isset($this->oauth_callback)? $this->oauth_callback: null,
         ]);
 
         $this->client->getEmitter()->attach($subscriber);

--- a/src/OAuth1ServiceInterface.php
+++ b/src/OAuth1ServiceInterface.php
@@ -4,6 +4,21 @@ namespace OAuth;
 interface OAuth1ServiceInterface extends ServiceInterface
 {
     /**
+     * Set the oauth callback URL to be used in requestToken()
+     *
+     * @param  string  $callback
+     * @return ServiceInterface
+     */
+    public function setOAuthCallback($callback);
+
+    /**
+     * Get the oauth callback URL to be used in requestToken()
+     *
+     * @return string
+     */
+    public function getOAuthCallback();
+
+    /**
      * Request a request token.
      * 
      * @return array

--- a/src/Services/Twitter.php
+++ b/src/Services/Twitter.php
@@ -6,16 +6,6 @@ use OAuth\OAuth1Service;
 class Twitter extends OAuth1Service
 {
     /**
-     * Set the oauth callback URL to be used in requestToken()
-     *
-     * @param  string  $callback
-     * @return void
-     */
-    public function setOAuthCallback($callback){
-        $this->oauth_callback = $callback;
-    }
-
-    /**
      * @var string
      */
     protected $endpointAuthorization = 'https://api.twitter.com/oauth/authenticate';

--- a/src/Services/Twitter.php
+++ b/src/Services/Twitter.php
@@ -6,6 +6,16 @@ use OAuth\OAuth1Service;
 class Twitter extends OAuth1Service
 {
     /**
+     * Set the oauth callback URL to be used in requestToken()
+     *
+     * @param  string  $callback
+     * @return void
+     */
+    public function setOAuthCallback($callback){
+        $this->oauth_callback = $callback;
+    }
+
+    /**
      * @var string
      */
     protected $endpointAuthorization = 'https://api.twitter.com/oauth/authenticate';

--- a/tests/unit/OAuth1ServiceTest.php
+++ b/tests/unit/OAuth1ServiceTest.php
@@ -29,6 +29,58 @@ class OAuth1ServiceTest extends PHPUnit_Framework_TestCase
      *
      * @test
      */
+    public function oauth_callback_setter_and_getter()
+    {
+        // Arrange
+        $service = new OAuth1Service;
+        $callbackUrl = 'http://callback-url.org/arrive';
+
+        //Act
+        $returned = $service->setOAuthCallback($callbackUrl)->getOAuthCallback();
+
+        //Assert
+        $this->assertEquals($callbackUrl, $returned);
+    }
+
+    /**
+     * Test the request token method with the optional callback url.
+     *
+     * @test
+     */
+    public function request_token_custom_callback()
+    {
+        // Arrange
+        $service = new OAuth1Service;
+        $credentials = [
+            'client_id' => 'cl13nt1d',
+            'client_secret' => 'cl13nts3cr3t',
+        ];
+        $body = [
+            'oauth_token' => 'O4thtOk3n',
+            'oauth_token_secret' => '04ths3cr3t',
+        ];
+        $custom_callback = 'http://callback-url.org/arrive';
+        $client = new Client;
+        $responseBody = Stream::factory(http_build_query($body));
+        $mock = new Mock([new Response(200, [], $responseBody)]);
+        $client->getEmitter()->attach($mock);
+
+        $service->setCredentials($credentials);
+        $service->setClient($client);
+        $service->setOAuthCallback($custom_callback);
+
+        // Act
+        $returned = $service->requestToken();
+
+        // Assert
+        $this->assertEquals($body, $returned);
+    }
+
+    /**
+     * Test the request token method.
+     *
+     * @test
+     */
     public function request_token()
     {
         // Arrange


### PR DESCRIPTION
Twitter has started requiring API clients set the callback parameter explicitly when requesting a request token. If you do not specify the callback twitter will as of 1/06/2015 redirect to the default url set in the app settings. The code in the pull request:
- Add a setOAuthCallback in the Twitter class to allow users to explicitly set the callback url
- The requestToken() of oauth1Service has been modified to check if the oauth_token has been set and pass it.
